### PR TITLE
Include 321db shim in pom

### DIFF
--- a/sql-plugin/pom.xml
+++ b/sql-plugin/pom.xml
@@ -661,7 +661,6 @@
                                         <patternset refid="spark340+.pattern"/>
                                         <exclude name="*nondb*/*"/>
 
-                                        <include name="311+-db/*"/>
                                         <include name="321db/*"/>
                                     </patternset>
                                     <include name="330db/*"/>

--- a/sql-plugin/pom.xml
+++ b/sql-plugin/pom.xml
@@ -662,6 +662,7 @@
                                         <exclude name="*nondb*/*"/>
 
                                         <include name="311+-db/*"/>
+                                        <include name="321db/*"/>
                                     </patternset>
                                     <include name="330db/*"/>
                                 </dirset>


### PR DESCRIPTION
Include 321db shim in pom file. 
Errors came down to 8 :)  

```
[INFO] --- scala-maven-plugin:3.4.4:compile (scala-compile-first) @ rapids-4-spark-sql_2.12 ---
[INFO] Using incremental compilation
[WARNING] Pruning sources from previous analysis, due to incompatible CompileSetup.
[INFO] Compiling 341 Scala sources and 59 Java sources to /home/ubuntu/spark-rapids-amahussein/spark-rapids/sql-plugin/target/spark330db/classes...
[ERROR] /home/ubuntu/spark-rapids-amahussein/spark-rapids/sql-plugin/src/main/330+/scala/com/nvidia/spark/rapids/shims/GpuHashPartitioning.scala:24: GpuHashPartitioning is already defined as case class GpuHashPartitioning
[ERROR] case class GpuHashPartitioning(expressions: Seq[Expression], numPartitions: Int)
[ERROR]            ^
[ERROR] /home/ubuntu/spark-rapids-amahussein/spark-rapids/sql-plugin/src/main/330+/scala/com/nvidia/spark/rapids/shims/GpuRangePartitioning.scala:37: GpuRangePartitioning is already defined as case class GpuRangePartitioning
[ERROR] case class GpuRangePartitioning(
[ERROR]            ^
[ERROR] /home/ubuntu/spark-rapids-amahussein/spark-rapids/sql-plugin/src/main/330+/scala/com/nvidia/spark/rapids/shims/RegExpShim.scala:19: RegExpShim is already defined as object RegExpShim
[ERROR] object RegExpShim {
[ERROR]        ^
[ERROR] /home/ubuntu/spark-rapids-amahussein/spark-rapids/sql-plugin/src/main/330+/scala/com/nvidia/spark/rapids/shims/Spark330PlusShims.scala:270: GpuDeterministicFirstLastCollectShim is already defined as trait GpuDeterministicFirstLastCollectShim
[ERROR] trait GpuDeterministicFirstLastCollectShim extends Expression
[ERROR]       ^
[ERROR] /home/ubuntu/spark-rapids-amahussein/spark-rapids/sql-plugin/src/main/330+/scala/org/apache/spark/sql/catalyst/csv/GpuCsvUtils.scala:22: GpuCsvUtils is already defined as object GpuCsvUtils
[ERROR] object GpuCsvUtils {
[ERROR]        ^
[ERROR] /home/ubuntu/spark-rapids-amahussein/spark-rapids/sql-plugin/src/main/330+/scala/org/apache/spark/sql/catalyst/json/GpuJsonUtils.scala:22: GpuJsonUtils is already defined as object GpuJsonUtils
[ERROR] object GpuJsonUtils {
[ERROR]        ^
[ERROR] /home/ubuntu/spark-rapids-amahussein/spark-rapids/sql-plugin/src/main/330db/scala/com/nvidia/spark/rapids/shims/SparkShims.scala:26: SparkShimImpl is already defined as object SparkShimImpl
[ERROR] object SparkShimImpl extends Spark331PlusShims {
[ERROR]        ^
[ERROR] /home/ubuntu/spark-rapids-amahussein/spark-rapids/sql-plugin/src/main/340+/scala/org/apache/spark/sql/rapids/shims/RapidsErrorUtils.scala:25: RapidsErrorUtils is already defined as object RapidsErrorUtils
[ERROR] object RapidsErrorUtils extends RapidsErrorUtilsFor330plus {
[ERROR]        ^
[ERROR] 8 errors found

```
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
